### PR TITLE
More compatibility improvements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='vertica-sqlalchemy',
-    version='0.14.2',
+    version='0.14.3',
     description='Vertica dialect for sqlalchemy',
     long_description=open("README.rst").read(),
     author='James Casbon',
@@ -22,4 +22,3 @@ setup(
     vertica.pyodbc = sqlalchemy_vertica.base:VerticaDialect
     """
 )
-

--- a/sqlalchemy_vertica/base.py
+++ b/sqlalchemy_vertica/base.py
@@ -182,6 +182,9 @@ class VerticaDialect(PyODBCConnector, PGDialect):
     def get_indexes(self, connection, table_name, schema, **kw):
         return []
 
+    def get_table_comment(self, connection, table_name, schema=None, **kw):
+        return {"text": None}
+
     # Disable index creation since that's not a thing in Vertica.
     def visit_create_index(self, create):
         return None


### PR DESCRIPTION
Create a faked-out version of get_table_comment(), ultimately used by pandas's df.to_sql() when dropping existing table.